### PR TITLE
timezone reported around epoch is unreliable, use a different number for date#create(number) tests

### DIFF
--- a/unit_tests/sugar/date.js
+++ b/unit_tests/sugar/date.js
@@ -10,6 +10,7 @@ test('Date', function () {
   var day, d, o;
   var timezoneOffset = new Date().getTimezoneOffset();
   var staticWinterTimezoneOffset = new Date(2011, 0, 1).getTimezoneOffset();
+  var staticJanDateNumber = 1000 * 60 * 60 * 24 * 14975; // 2011-01-01 00:00:00 
   var staticSummerTimezoneOffset = new Date(2011, 8, 1).getTimezoneOffset();
   var now = new Date();
   var thisYear = now.getFullYear();
@@ -70,7 +71,7 @@ test('Date', function () {
 
   dateEquals(new Date(new Date(2008, 6, 22)), new Date(2008, 6, 22), 'Date | date accepts itself as a constructor');
 
-  dateEquals(Date.create(0), new Date(1970, 0, 1, 0, -staticWinterTimezoneOffset) , 'Date#create | Accepts numbers');
+  dateEquals(Date.create(staticJanDateNumber), new Date(2011, 0, 1, 0, -staticWinterTimezoneOffset) , 'Date#create | Accepts numbers');
   dateEquals(Date.create('1999'), new Date(1999, 0), 'Date#create | Just the year');
 
   dateEquals(Date.create('June'), new Date(thisYear, 5), 'Date#create | Just the month');
@@ -1107,7 +1108,7 @@ test('Date', function () {
   equals(getDateWithWeekdayAndOffset(0).is('the beginning of the week'), true, 'Date#is | the beginning of the week');
   equals(getDateWithWeekdayAndOffset(6, 0, 23, 59, 59, 999).is('the end of the week'), true, 'Date#is | the end of the week');
 
-  equals(new Date(1970, 0, 1, 0, -staticWinterTimezoneOffset).is(0), true, 'Date#is | Accepts numbers');
+  equals(new Date(2011, 0, 1, 0, -staticWinterTimezoneOffset).is(staticJanDateNumber), true, 'Date#is | Accepts numbers');
 
 
 


### PR DESCRIPTION
The timezoneoffset reported around the epoch ( new Date( 0 ) ) is unreliable. eg:

> new Date(0)
> Thu Jan 01 1970 10:00:00 GMT+1000 (EST)
> new Date(1970, 0, 1)
> Thu Jan 01 1970 00:00:00 GMT+1100 (EST)

on some browser / os / locale combinations
 so I have change the number to test from 0 to 1293840000000 (which is 2011-01-01 00:00:00 ) which should reliably return a 'winter' effected timezone.

btw: for the southern hemisphere: staticWinterTimezoneOffset is a confusing variable name, but I get what you mean ;)

see also http://code.google.com/p/chromium/issues/detail?id=30910
