### PR TITLE
"GMT{tz}" is not a valid timezone for RFCs 1036 and 1123 (RFC 822)

### DIFF
--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -5253,8 +5253,8 @@
   var setDateProperties = function() {
     Date.DSTOffset = (new Date(2000, 6, 1).getTimezoneOffset() - new Date(2000, 0, 1).getTimezoneOffset()) * 60 * 1000;
     Date.INTERNATIONAL_TIME = '{h}:{mm}:{ss}';
-    Date.RFC1123 = '{Dow}, {dd} {Mon} {yyyy} {hh}:{mm}:{ss} GMT{tz}';
-    Date.RFC1036 = '{Weekday}, {dd}-{Mon}-{yy} {hh}:{mm}:{ss} GMT{tz}';
+    Date.RFC1123 = '{Dow}, {dd} {Mon} {yyyy} {hh}:{mm}:{ss} {tz}';
+    Date.RFC1036 = '{Weekday}, {dd}-{Mon}-{yy} {hh}:{mm}:{ss} {tz}';
     Date.ISO8601_DATE = '{yyyy}-{MM}-{dd}';
     Date.ISO8601_DATETIME = '{yyyy}-{MM}-{dd}T{hh}:{mm}:{ss}.{ms}{isotz}';
     Date.ISO8601 = Date.ISO8601_DATETIME;


### PR DESCRIPTION
Valid cases:

With GMT: Fri, 19 Nov 82 16:14:55 GMT
With offset: Sat, 1 Jan 83 00:00:00 -0500

Regards
