### PR TITLE
Spacify function

### DIFF
--- a/lib/sugar.js
+++ b/lib/sugar.js
@@ -3405,6 +3405,22 @@
     },
 
     /***
+     * @method spacify([first] = true)
+     * @returns String
+     * @short Converts camel case, underscores, and hyphens to a properly spaced string. If [first] is true the first letter will also be capitalized.
+     * @example
+     * 
+     *   'camelCase'.spacify()              -> 'Camel case'
+     *   'an-ugly-string'.spacify(false)    -> 'an ugly string'
+     *   'something_else'.spacify()         -> 'Something else'
+     * 
+    ***/
+    'spacify': function(first) {
+      if(first === false) return this.underscore().replace(/_/g, ' ');
+      else return this.underscore().replace(/_/g, ' ').replace(/^./, function(str){ return str.toUpperCase(); });
+    },
+    
+    /***
      * @method stripTags([tag1], [tag2], ...)
      * @returns String
      * @short Strips all HTML tags from the string.


### PR DESCRIPTION
Added a spacify function. Converts camel case, underscores, and hyphens to a properly spaced string.
