### PR TITLE
Protect against hasOwnProperty being overwritten

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -62,10 +62,14 @@
     }
   }
 
+  function has(obj, key) {
+    return object.prototype.hasOwnProperty.call(obj, key);
+  }
+
   function iterateOverObject(obj, fn) {
     var count = 0;
     for(var key in obj) {
-      if(!obj.hasOwnProperty(key)) continue;
+      if(!has(obj, key)) continue;
       fn.call(obj, key, obj[key], count);
       count++;
     }
@@ -92,8 +96,8 @@
       }
       stack.push(a);
       for(var key in a) {
-        if(!a.hasOwnProperty(key)) continue;
-        if(!b.hasOwnProperty(key) || !equal(a[key], b[key], stack)) {
+        if(!has(a, key)) continue;
+        if(!has(b, key) || !equal(a[key], b[key], stack)) {
           return false;
         }
       }
@@ -541,6 +545,21 @@
     'tap': function(obj, fn) {
       transformArgument(obj, fn, obj, [obj]);
       return obj;
+    },
+
+    /***
+     * @method has(<obj>, <key>)
+     * @returns Boolean
+     * @short Checks if <obj> has <key> using hasOwnProperty from Object.prototype
+     * @extra See http://www.devthought.com/2012/01/18/an-object-is-not-a-hash/
+     * @example
+     *
+     *   Object.has({ foo: 'bar' }, 'foo') -> true
+     *   Object.has({ foo: 'bar' }, 'baz') -> false
+     *   Object.has({ hasOwnProperty: true }, 'foo') -> false
+     ***/
+    'has': function (obj, key) {
+      return has(obj, key);
     }
 
   });
@@ -3394,7 +3413,7 @@
         }
       });
       return this.replace(/\{(.+?)\}/g, function(m, key) {
-        return assign.hasOwnProperty(key) ? assign[key] : m;
+        return has(assign, key) ? assign[key] : m;
       });
     },
 
@@ -3842,7 +3861,7 @@
     'once': function() {
       var fn = this;
       return function() {
-        return fn.hasOwnProperty('memo') ? fn['memo'] : fn['memo'] = fn.apply(this, arguments);
+        return has(fn, 'memo') ? fn['memo'] : fn['memo'] = fn.apply(this, arguments);
       }
     },
 

--- a/unit_tests/environments/sugar/object.js
+++ b/unit_tests/environments/sugar/object.js
@@ -720,6 +720,11 @@ test('Object', function () {
   var obj = { foo: 'bar' };
   equal(Object.tap(obj), obj, 'Object.tap | return value is strictly equal');
 
+  // Object.has
+
+  equal(Object.has({ foo: 'bar' }, 'foo'), true, 'Object.has | finds a property');
+  equal(Object.has({ foo: 'bar' }, 'baz'), false, 'Object.has | does not find a nonexistant property');
+  equal(Object.has({ hasOwnProperty: true, foo: 'bar' }, 'foo'), true, 'Object.has | local hasOwnProperty is ignored');
 
   // Class.extend functionality
 


### PR DESCRIPTION
See [this blog post](http://www.devthought.com/2012/01/18/an-object-is-not-a-hash/) for rationale.

Currently, Sugar is susceptible to this bug in a few places, notably Object.extended:

``` javascript
Object.extended({ hasOwnProperty: true }) // TypeError: obj.hasOwnProperty is not a function
```

This PR adds `Object.has` as a shortcut to `Object.prototype.hasOwnProperty`, and replaces internal use of `Object#hasOwnProperty`.
