### PR TITLE
String#capitalize and Unicode chars

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -2730,7 +2730,7 @@
      *
      ***/
     'capitalize': function(all) {
-      var reg = all ? /\b[a-z]/g : /^[a-z]/;
+      var reg = all ? /^\S|\s\S/g : /^\S/;
       return this.toLowerCase().replace(reg, function(letter) {
         return letter.toUpperCase();
       });

--- a/unit_tests/environments/sugar/string.js
+++ b/unit_tests/environments/sugar/string.js
@@ -88,10 +88,12 @@ test('String', function () {
   equal('reuben sandwich'.capitalize(), 'Reuben sandwich', 'String#capitalize | should capitalize first letter of first word only.', { mootools: 'Reuben Sandwich' });
   equal('Reuben sandwich'.capitalize(), 'Reuben sandwich', 'String#capitalize | should leave the string alone', { mootools: 'Reuben Sandwich' });
   equal('REUBEN SANDWICH'.capitalize(), 'Reuben sandwich', 'String#capitalize | should uncapitalize all other letters', { mootools: 'REUBEN SANDWICH' });
+  equal('фыва йцук'.capitalize(), 'Фыва йцук', 'String#capitalize | should capitalize unicode letters', { mootools: 'Фыва йцук' });
 
   equal('reuben sandwich'.capitalize(true), 'Reuben Sandwich', 'String#capitalize | all | should capitalize all first letters', { prototype: 'Reuben sandwich' });
   equal('Reuben sandwich'.capitalize(true), 'Reuben Sandwich', 'String#capitalize | all | should capitalize the second letter only', { prototype: 'Reuben sandwich' });
   equal('REUBEN SANDWICH'.capitalize(true), 'Reuben Sandwich', 'String#capitalize | all | should uncapitalize all other letters', { prototype: 'Reuben sandwich', mootools: 'REUBEN SANDWICH' });
+  equal('фыва йцук'.capitalize(true), 'Фыва Йцук', 'String#capitalize | all | should capitalize unicode letters', { prototype: 'Фыва йцук' });
   equal('what a shame of a title'.capitalize(true), 'What A Shame Of A Title', 'String#capitalize | all | all lower-case', { prototype: 'What a shame of a title' });
   equal('What A Shame Of A Title'.capitalize(true), 'What A Shame Of A Title', 'String#capitalize | all | already capitalized', { prototype: 'What a shame of a title' });
   equal(' what a shame of a title    '.capitalize(true), ' What A Shame Of A Title    ', 'String#capitalize | all | preserves whitespace', { prototype: ' what a shame of a title    ' });


### PR DESCRIPTION
I have found that Sugar's capitalize does not work with Unicode chars:

```
"фыва йцук".capitalize() # should be "Фыва йцук", but returns the same string.
```

At the same time, toUpperCase works correctly.

I understand, that the root of issue is that ECMAScript standard in all browsers provides non-Unicode RegExps. So I made a shim-solution, that works well on tests and in real world.
