### PR TITLE
When iterating over objects, only operate on enumerable properties

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -69,7 +69,7 @@
   function iterateOverObject(obj, fn) {
     var key;
     for(key in obj) {
-      if(!hasOwnProperty(obj, key)) continue;
+      if(!hasOwnProperty(obj, key) || !object.prototype.propertyIsEnumerable.call(obj, key)) continue;
       fn.call(obj, key, obj[key]);
     }
   }


### PR DESCRIPTION
I'm not sure if this would have any negative consequences, but it seems like the right thing to do.
