### PR TITLE
Fix for issue # 125

### DIFF
--- a/lib/dates-only.js
+++ b/lib/dates-only.js
@@ -1849,7 +1849,8 @@
           }
 
           // Adjust for timezone offset
-          if(set['offset_hours'] || set['offset_minutes']) {
+          if((set['offset_hours'] != undefined && set['offset_hours'] != null) ||
+                  (set['offset_minutes'] != undefined && set['offset_hours'])) {
             set['utc'] = true;
             set['offset_minutes'] = set['offset_minutes'] || 0;
             set['offset_minutes'] += set['offset_hours'] * 60;

--- a/lib/dates.js
+++ b/lib/dates.js
@@ -616,7 +616,8 @@
           }
 
           // Adjust for timezone offset
-          if(set['offset_hours'] || set['offset_minutes']) {
+          if((set['offset_hours'] != undefined && set['offset_hours'] != null) ||
+                  (set['offset_minutes'] != undefined && set['offset_hours'])){
             set['utc'] = true;
             set['offset_minutes'] = set['offset_minutes'] || 0;
             set['offset_minutes'] += set['offset_hours'] * 60;


### PR DESCRIPTION
When creating date with timezone offset of ±00:00 the check for offset_minutes and offset_hours resolved to false since the values were 0.  This prevented the date from being treated as relative to utc.

Changed the check to verify values are not undefined or null.
