### PR TITLE
Add the "size" method to count the length of an object

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -591,12 +591,10 @@
      * @method size(<obj>)
      * @returns integer
      * @short Returns 0 if <obj> is empty.
-     * @extra %size% is available as an instance method on extended objects.
      * @example
      *
-     *   Object.size({})          -> true
+     *   Object.size({})          -> 0
      *   Object.size({foo:'bar'}) -> 1
-     *   Object.extended({foo:'bar'}).size() -> false
      *
      ***/
     'size': function(obj) {


### PR DESCRIPTION
Since objects do not have the attribute 'length' and sometimes we need count a JSON, for example, I think it would be interesting to have that method.
