### PR TITLE
Parses 'just now' correctly

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -1820,10 +1820,6 @@
     }, false, false);
   }
 
-  function cleanDate() {
-    
-  }
-
   function buildDate() {
     English = date.setLocale('en');
     buildDateUnits();


### PR DESCRIPTION
Add a string replace to correctly parse 'just now' as ' now' which will perform the desired behavior based on current functionality.
