### PR TITLE
Fixes issue in Object.fromQueryString where urlencoded url query string breaks the result

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -292,10 +292,10 @@
     'fromQueryString': function(str, deep) {
       var result = object.extended(), split;
       str = str && str.toString ? str.toString() : '';
-      decodeURIComponent(str.replace(/^.*?\?/, '')).split('&').forEach(function(p) {
+      str.replace(/^.*?\?/, '').split('&').forEach(function(p) {
         var split = p.split('=');
         if(split.length !== 2) return;
-        setParamsObject(result, split[0], split[1], deep);
+        setParamsObject(result, split[0], decodeURIComponent(split[1]), deep);
       });
       return result;
     },


### PR DESCRIPTION
...?_host=http%3A%2F%2Fwww.site.com%2Fslug%3Fin%3D%2Fuser%2Fjoeyblake

This would decode before being parsed into an object. And It would fail because there were two '=' in the resulting string.  Decoding just the result fixes this issue
