### PR TITLE
Fix unit test failure in #208

### DIFF
--- a/unit_tests/environments/sugar/date_da.js
+++ b/unit_tests/environments/sugar/date_da.js
@@ -15,7 +15,7 @@ test('Dates | Danish', function () {
     'Date#create | basic Danish date'
   );
 
-  dateEqual(Date.create('tirsdag 5 januari 2012'),
+  dateEqual(Date.create('tirsdag 5 januar 2012'),
     new Date(2012, 0, 5),
     'Date#create | Danish | 2012-01-05'
   );


### PR DESCRIPTION
"januari" => "januar", should now be fixed. Running `unit_tests/date.html` results in 0 failures here.
