### PR TITLE
Fixed setParamsObject for better float handling

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -1,4 +1,3 @@
-
   /***
    * @package Object
    * @dependency core
@@ -28,7 +27,7 @@
       });
       if(!key && paramIsArray) key = obj.length.toString();
       setParamsObject(obj, key, value);
-    } else if(value.match(/^[\d.]+$/)) {
+    } else if(value.match(/^[+-]?\d+(\.\d+)?$/)) {
       obj[param] = parseFloat(value);
     } else if(value === 'true') {
       obj[param] = true;


### PR DESCRIPTION
Existing regex treated IPs like float values.
