### PR TITLE
unescapeHTML() bug fix

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -219,12 +219,12 @@
       *
       ***/
     'unescapeHTML': function() {
-      return this.replace(/&amp;/g,  '&')
-                 .replace(/&lt;/g,   '<')
+      return this.replace(/&lt;/g,   '<')
                  .replace(/&gt;/g,   '>')
                  .replace(/&quot;/g, '"')
                  .replace(/&apos;/g, "'")
-                 .replace(/&#x2f;/g, '/');
+                 .replace(/&#x2f;/g, '/')
+                 .replace(/&amp;/g,  '&');
     },
 
      /***

--- a/release/sugar-full.development.js
+++ b/release/sugar-full.development.js
@@ -5944,12 +5944,12 @@
       *
       ***/
     'unescapeHTML': function() {
-      return this.replace(/&amp;/g,  '&')
-                 .replace(/&lt;/g,   '<')
+      return this.replace(/&lt;/g,   '<')
                  .replace(/&gt;/g,   '>')
                  .replace(/&quot;/g, '"')
                  .replace(/&apos;/g, "'")
-                 .replace(/&#x2f;/g, '/');
+                 .replace(/&#x2f;/g, '/')
+                 .replace(/&amp;/g,  '&');
     },
 
      /***

--- a/unit_tests/environments/sugar/string.js
+++ b/unit_tests/environments/sugar/string.js
@@ -71,7 +71,8 @@ test('String', function () {
   equal('I know that &quot;feel&quot; bro'.unescapeHTML(), 'I know that "feel" bro', 'String#unescapeHTML | works on "');
   equal('feel the &#x2f;'.unescapeHTML(), 'feel the /', 'String#unescapeHTML | works on /');
 
-
+  equal('&gt;'.escapeHTML().unescapeHTML(), '&gt;', 'String#unescapeHTML | is the reverse of escapeHTML');
+  equal('&amp;lt;'.unescapeHTML(), '&lt;', 'String#unescapeHTML | unescapes a single level of HTML escaping');
 
   equal('This webpage is not available'.encodeBase64(), 'VGhpcyB3ZWJwYWdlIGlzIG5vdCBhdmFpbGFibGU=', 'String#encodeBase64 | webpage');
   equal('I grow, I prosper; Now, gods, stand up for bastards!'.encodeBase64(), 'SSBncm93LCBJIHByb3NwZXI7IE5vdywgZ29kcywgc3RhbmQgdXAgZm9yIGJhc3RhcmRzIQ==', 'String#encodeBase64 | gods');


### PR DESCRIPTION
unescapeHTML() unescapes two layers of escape codes that have been escaped multiple times. For example:

  '&amp;amp;gt;'.unescapeHTML() == '>' // true
  '&amp;gt;'.escapeHTML().unescapeHTML() != '&amp;gt;' // true

My change fixes this so that only one layer of HTML escaping is unescaped:

  '&amp;amp;gt;'.unescapeHTML() == '&amp;gt;' // true
  '&amp;gt;'.escapeHTML().unescapeHTML() == '&amp;gt;' // true
