### PR TITLE
Optimize multiMatch by evaluating the matcher once

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -7,30 +7,44 @@
    *
    ***/
 
-
-  function multiMatch(el, match, scope, params) {
-    var result = true;
-    if(el === match) {
-      // Match strictly equal values up front.
-      return true;
-    } else if(isRegExp(match) && isString(el)) {
-      // Match against a regexp
-      return regexp(match).test(el);
+  function getMatcher(match) {
+    if (isRegExp(match)) {
+      match = regexp(match); // For some reasons I don't know we have this!
+      return function (el) {
+        if(isString(el))
+          return match.test(el);
+      };
     } else if(isFunction(match)) {
-      // Match against a filtering function
-      return match.apply(scope, params);
-    } else if(isObject(match) && isObjectPrimitive(el)) {
-      // Match against a hash or array.
-      iterateOverObject(match, function(key, value) {
-        if(!multiMatch(el[key], match[key], scope, [el[key], el])) {
-          result = false;
+      return function (el, scope, params) {
+        return !!match.apply(scope, params);
+      };
+    } else if(isObject(match)) {
+      return function (el, scope) {
+        if (isObjectPrimitive(el)) {
+          var result = true;
+          iterateOverObject(match, function(key, value) {
+            if(!multiMatch(el[key], match[key], getMatcher(match[key]), scope, [el[key], el])) {
+              result = false;
+            }
+          });
+          return result;
         }
-      });
+      };
+    }
+  }
+  
+  function multiMatch(el, match, matcher, scope, params) {
+    if(el === match) {
+      return true;
+    }
+    var result = matcher && matcher(el, scope, params);
+    if(result !== undefined) {
       return result;
     } else {
       return isEqual(el, match);
     }
   }
+
 
   function transformArgument(el, map, context, mapArgs) {
     if(isUndefined(map)) {
@@ -84,9 +98,10 @@
   }
 
   function arrayFind(arr, f, startIndex, loop, returnIndex) {
-    var result, index;
+    var result, index, matcher;
     arrayEach(arr, function(el, i, arr) {
-      if(multiMatch(el, f, arr, [el, i, arr])) {
+      matcher = matcher || getMatcher(f);
+      if(multiMatch(el, f, matcher, arr, [el, i, arr])) {
         result = el;
         index = i;
         return false;
@@ -270,11 +285,13 @@
     var callbackCheck = function() { var a = arguments; return a.length > 0 && !isFunction(a[0]); };
     extendSimilar(array, true, callbackCheck, 'map,every,all,some,any,none,filter', function(methods, name) {
       methods[name] = function(f) {
+        var matcher;
         return this[name](function(el, index) {
           if(name === 'map') {
             return transformArgument(el, f, this, [el, index, this]);
           } else {
-            return multiMatch(el, f, this, [el, index, this]);
+            matcher = matcher || getMatcher(f);
+            return multiMatch(el, f, matcher, this, [el, index, this]);
           }
         });
       }
@@ -368,9 +385,10 @@
      *
      ***/
     'findAll': function(f, index, loop) {
-      var result = [];
+      var matcher, result = [];
       arrayEach(this, function(el, i, arr) {
-        if(multiMatch(el, f, arr, [el, i, arr])) {
+        matcher = matcher || getMatcher(f);
+        if(multiMatch(el, f, matcher, arr, [el, i, arr])) {
           result.push(el);
         }
       }, index, loop);
@@ -392,7 +410,7 @@
      *
      ***/
     'findIndex': function(f, startIndex, loop) {
-      var index = arrayFind(this, f, startIndex, loop, true);
+    var index = arrayFind(this, f, startIndex, loop, true);
       return isUndefined(index) ? -1 : index;
     },
 
@@ -977,7 +995,8 @@
       multiArgs(arguments, function(f) {
         i = 0;
         while(i < arr.length) {
-          if(multiMatch(arr[i], f, arr, [arr[i], i, arr])) {
+          var matcher = matcher || getMatcher(f);
+          if(multiMatch(arr[i], f, matcher, arr, [arr[i], i, arr])) {
             arr.splice(i, 1);
           } else {
             i++;
@@ -1135,12 +1154,13 @@
   function buildEnumerableMethods(names, mapping) {
     extendSimilar(object, false, false, names, function(methods, name) {
       methods[name] = function(obj, arg1, arg2) {
-        var result, coerced = keysWithCoercion(obj);
+        var result, matcher, coerced = keysWithCoercion(obj);
         result = array.prototype[name].call(coerced, function(key) {
           if(mapping) {
             return transformArgument(obj[key], arg1, obj, [key, obj[key], obj]);
           } else {
-            return multiMatch(obj[key], arg1, obj, [key, obj[key], obj]);
+            matcher = matcher || getMatcher(arg1);
+            return multiMatch(obj[key], arg1, matcher, obj, [key, obj[key], obj]);
           }
         }, arg2);
         if(isArray(result)) {


### PR DESCRIPTION
Note that the getMatcher should be called lazily in the iterator callback
function or emptyArray.find(..) will be slower.

Benchmark: https://gist.github.com/alFReD-NSH/4994209

Before:

emptyArray.Find(emptyFunction) x 982,473 ops/sec ±13.16% (38 runs sampled)
arrayWith500.Find(emptyFunction) x 733 ops/sec ±5.33% (50 runs sampled)

After:

emptyArray.Find(emptyFunction) x 998,526 ops/sec ±0.64% (54 runs sampled)
arrayWith500.Find(emptyFunction) x 1,577 ops/sec ±14.83% (28 runs sampled)
