### PR TITLE
Travis CI should also test in newer versions of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - 0.6
+  - "0.10"
+  - "0.8"
+  - "0.6"
 branches:
   only:
     - master


### PR DESCRIPTION
Node.js version `0.6` listed in `.travis.yml` is slightly outdated, version 0.10 is currently the latest stable.

I've added `0.10` and `0.8` to test in, and also quoted them (`0.6`→`"0.6"`) as in the corresponding [example](http://about.travis-ci.org/docs/user/languages/javascript-with-nodejs/#Choosing-Node-versions-to-test-against).
