### PR TITLE
Handle numbers with leading zeros as strings in Object.fromQueryString.

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -30,7 +30,7 @@
       });
       if(!key && paramIsArray) key = obj.length.toString();
       setParamsObject(obj, key, value);
-    } else if(value.match(/^[+-]?\d+(\.\d+)?$/)) {
+    } else if(value.match(/^[+-]?\d+(\.\d+)?$/) && value === parseFloat(value)+"") {
       obj[param] = parseFloat(value);
     } else if(value === 'true') {
       obj[param] = true;

--- a/test/environments/sugar/object.js
+++ b/test/environments/sugar/object.js
@@ -687,6 +687,7 @@ test('Object', function () {
 
   equal(Object.fromQueryString('foo=3.14156'), { foo: 3.14156 }, 'Object.fromQueryString | can handle float values');
   equal(Object.fromQueryString('foo=127.0.0.1'), { foo: '127.0.0.1' }, 'Object.fromQueryString | IP addresses not treated as numbers');
+  equal(Object.fromQueryString('zip=00123'), { zip: '00123' }, 'Object.fromQueryString | zip codes with leading zeros not treated as numbers');
 
 
 


### PR DESCRIPTION
I ran into the issue where having a zip code with leading zeros (like 00123) as a URL parameter was parsed as a number instead of a string, which led to the zeros being dropped.

My approach here is to make sure that the string representation of the parsed value would match the original string value before using parseFloat to assign the parameter's value. I suppose this could break on large float values.

Any comments welcome!
