### PR TITLE
Fix .startsWith and .endsWith with regular expressions.

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -177,7 +177,7 @@
       if(pos) str = str.slice(pos);
       if(isUndefined(c)) c = true;
       source = isRegExp(reg) ? reg.source : escapeRegExp(reg);
-      return regexp('^' + source, c ? '' : 'i').test(str);
+      return regexp('^(?:' + source + ')', c ? '' : 'i').test(str);
     },
 
     /***
@@ -199,7 +199,7 @@
       if(isDefined(pos)) str = str.slice(0, pos);
       if(isUndefined(c)) c = true;
       source = isRegExp(reg) ? reg.source : escapeRegExp(reg);
-      return regexp(source + '$', c ? '' : 'i').test(str);
+      return regexp('(?:' + source + ')$', c ? '' : 'i').test(str);
     }
 
   });

--- a/test/environments/sugar/string.js
+++ b/test/environments/sugar/string.js
@@ -398,6 +398,7 @@ test('String', function () {
   equal('hello'.startsWith(/[a-h]/, 0, true), true, 'String#startsWith | accepts regex alternates', { prototype: false });
   equal('^ello'.startsWith(/\^/, 0, false), true, 'String#startsWith | accepts regex with ^', { prototype: false });
   equal('hello'.startsWith(/[^h]/, 0, false), false, 'String#startsWith | accept regex with negated alternates', { prototype: false });
+  equal('hello'.startsWith(/el|lo/, 0, false), false, 'String#startsWith | accept regex with alternation', { prototype: false });
   equal('HELLO'.startsWith('hell', 0, false), true, 'String#startsWith | case insensitive | HELLO starts with hell', { prototype: false });
   equal('HELLO'.startsWith(), false, 'String#startsWith | undefined produces false');
   equal('hello'.startsWith('hell', -20, true), true, 'String#startsWith | from pos -20');
@@ -419,6 +420,7 @@ test('String', function () {
   equal('vader'.endsWith(/der/, 5, true), true, 'String#endsWith | accepts regex', { prototype: false });
   equal('vader'.endsWith(/[q-z]/, 5, true), true, 'String#endsWith | accepts regex alternates', { prototype: false });
   equal('vade$'.endsWith(/\$/, 5, true), true, 'String#endsWith | accepts regex with $', { prototype: false });
+  equal('vader'.endsWith(/va|de/, 0, false), false, 'String#endsWith | accept regex with alternation', { prototype: false });
   equal('VADER'.endsWith('der', 5, false), true, 'String#endsWith | case insensitive |  VADER ends with der', { prototype: false });
   equal('VADER'.endsWith('DER', 5, true), true, 'String#endsWith | case sensitive | VADER ends with DER');
   equal('VADER'.endsWith('der', 5, true), false, 'String#endsWith | case sensitive |  VADER ends with der');


### PR DESCRIPTION
First of all, I'm already aware builds for this test fail (however, they don't fail on Travis, some bug testing problem?) - this is caused by me not knowing how to compile files in `release` (I tried using `create_release.rb`, but it doesn't work for me). Anyway, I decided to remove `.replace()`, as the `.replace` here is IMO pointless, and only added bugs.

The old code was replacing `^` with nothing (only once, for some reason). I believe it's a mistake, as it breaks regular expressions containing `^` (most notably, escaped `^` and negated character ranges, like `[^abc]`). It causes lots of interesting bugs. If you change `/\^/` into `/^\/`, you get a syntax error. Similarly, if you change `/[^k]/` into `/^[k]/`, you make opposite of what user intended. This is bad. The regular expression like `/^^^^^^^^^^^^^^^^/` means exactly the same thing as `/^/` (ignoring [certain old, already fixed bug in V8](https://code.google.com/p/v8/issues/detail?id=909)), so the removal is not even necessary.

There is also another bug, not related to replacement - the code was adding `^` or `$` without ensuring correct precedence. I've added parens, in order to ensure regular expression like `/a|b/` will be parsed as `/^(?:a|b)/`, not `/^a|b/`.
