### PR TITLE
Escape dash in `Regexp.escape`.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -451,7 +451,7 @@
 
   function escapeRegExp(str) {
     if(!isString(str)) str = string(str);
-    return str.replace(/([\\/\'*+?|()\[\]{}.^$])/g,'\\$1');
+    return str.replace(/([\\/\'*+?|()\[\]{}.^$\-])/g,'\\$1');
   }
 
 

--- a/test/environments/sugar/regexp.js
+++ b/test/environments/sugar/regexp.js
@@ -14,7 +14,7 @@ test('RegExp', function () {
   equal(RegExp.escape('hey there (budday)'), 'hey there \\(budday\\)', 'RegExp#escape');
   equal(RegExp.escape('what a day...'), 'what a day\\.\\.\\.', 'RegExp#escape');
   equal(RegExp.escape('.'), '\\.', 'RegExp#escape');
-  equal(RegExp.escape('*.+[]{}()?|/\\'), '\\*\\.\\+\\[\\]\\{\\}\\(\\)\\?\\|\\/\\\\', 'RegExp#escape');
+  equal(RegExp.escape('*.+[]{}()?|/\\-'), '\\*\\.\\+\\[\\]\\{\\}\\(\\)\\?\\|\\/\\\\\\-', 'RegExp#escape');
   equal(RegExp.escape('?'), '\\?', 'RegExp#escape | ?');
   equal(RegExp.escape('\?'), '\\?', 'RegExp#escape | one slash and ?');
   equal(RegExp.escape('\\?'), '\\\\\\?', 'RegExp#escape | two slashes and ?');


### PR DESCRIPTION
This lets you write code like `RegExp("[" + RegExp.escape(something) + "]")` work, without having to worry about dashes working as ranges.

Possible backward incompatibile issues: It breaks code that did `RegExp.escape(something).replace(/-/g, "\\-")`.
