### PR TITLE
Parity for non-integers.

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -148,7 +148,7 @@
      *
      ***/
     'isOdd': function() {
-      return !isNaN(this) && !this.isMultipleOf(2);
+      return this.isInteger() && !this.isMultipleOf(2);
     },
 
     /***

--- a/test/environments/sugar/number.js
+++ b/test/environments/sugar/number.js
@@ -214,6 +214,8 @@ test('Number', function () {
   equal((24).isOdd(), false, 'Number#isOdd | 24');
   equal((200).isOdd(), false, 'Number#isOdd | 200');
   equal((NaN).isOdd(), false, 'Number#isOdd | NaN');
+  equal((0.1).isOdd(), false, 'Number#isOdd | 0.1');
+  equal((Infinity).isOdd(), false, 'Number#isOdd | Infinity')
 
 
 
@@ -224,6 +226,8 @@ test('Number', function () {
   equal((24).isEven(), true, 'Number#isEven | 24');
   equal((200).isEven(), true, 'Number#isEven | 200');
   equal((NaN).isEven(), false, 'Number#isEven | NaN');
+  equal((0.1).isEven(), false, 'Number#isEven | 0.1');
+  equal((Infinity).isEven(), false, 'Number#isEven | Infinity')
 
 
 


### PR DESCRIPTION
1. All non-integers are odd in Sugar. This is wrong as parity is only defined for integers.
   
   ``` js
   (1.1).isEven(); // => false
   (1.1).isOdd(); // => true, expected false
   ```
2. ±`Infinity` is also odd in Sugar.
   
   ``` js
   Infinity.isEven(); // => false
   Infinity.isOdd(); // => true
   ```
   
   The Mathematics Stack Exchange tries to answer the question of whether [infinity is an odd or even number](http://math.stackexchange.com/questions/49034/is-infinity-an-odd-or-even-number). [One such answer](http://math.stackexchange.com/a/49046) is that the “smallest infinity <i>ω</i> is even, <i>ω</i> + 1 is odd,” etc. But I believe this goes too far for what JavaScript is expected to handle.
   
   In JavaScript `1 + Infinity === Infinity`, according to [atleast one answer on SE](http://math.stackexchange.com/a/49039) “this may yield an obstruction to extending parity arithmetic”. In other words, parity cannot be defined. That’s also what I think should be happening in Sugar.
   
   Either way, Sugar is declaring `Infinity` to be odd, which is wrong in both cases.

This proposed fix returns `false` for all non-integer numbers: `NaN`, `Infinity`, and those with a decimal component.
