### PR TITLE
Missing 'tokens' and 'articles'

### DIFF
--- a/lib/locales/pl.js
+++ b/lib/locales/pl.js
@@ -42,6 +42,8 @@
 
 Date.addLocale('pl', {
   'plural':    true,
+  'articles':  '',
+  'tokens':    '',
   'months':    'Styczeń|Stycznia,Luty|Lutego,Marzec|Marca,Kwiecień|Kwietnia,Maj|Maja,Czerwiec|Czerwca,Lipiec|Lipca,Sierpień|Sierpnia,Wrzesień|Września,Październik|Października,Listopad|Listopada,Grudzień|Grudnia',
   'weekdays':  'Niedziela|Niedzielę,Poniedziałek,Wtorek,Środ:a|ę,Czwartek,Piątek,Sobota|Sobotę',
   'units':     'milisekund:a|y|,sekund:a|y|,minut:a|y|,godzin:a|y|,dzień|dni,tydzień|tygodnie|tygodni,miesiące|miesiące|miesięcy,rok|lata|lat',
@@ -54,7 +56,7 @@ Date.addLocale('pl', {
   'future':    '{sign} {num} {unit}',
   'duration':  '{num} {unit}',
   'timeMarker':'o',
-  'ampm':      'am,pm',
+  'ampm':      '',
   'modifiers': [
     { 'name': 'day', 'src': 'przedwczoraj', 'value': -2 },
     { 'name': 'day', 'src': 'wczoraj', 'value': -1 },


### PR DESCRIPTION
Without 'tokens' and/or 'articles' some regexp starts with "undefined":
^(?:undefined)
