### PR TITLE
Specify that sortBy returns a new array.

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -1068,7 +1068,7 @@
     /***
      * @method sortBy(<map>, [desc] = false)
      * @returns Array
-     * @short Sorts the array by <map>.
+     * @short Returns a copy of the array sorted by <map>.
      * @extra <map> may be a function, a string acting as a shortcut, an array (comparison by multiple values), or blank (direct comparison of array values). [desc] will sort the array in descending order. When the field being sorted on is a string, the resulting order will be determined by an internal collation algorithm that is optimized for major Western languages, but can be customized. For more information see @array_sorting.
      * @example
      *


### PR DESCRIPTION
Native Array.sort() sorts in-place, so this documentation should be clear that it's different.