### PR TITLE
Added support for Date.create('Now')

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -884,7 +884,7 @@
       if(!set) {
         // The Date constructor does something tricky like checking the number
         // of arguments so simply passing in undefined won't work.
-        if(f !== 'now') {
+        if(!/^now$/i.test(f)) {
           d = new date(f);
         }
         if(forceUTC) {


### PR DESCRIPTION
Other strings such as `today` and `yesterday` can also be parsed as `Today` and `Yesterday`, but this does not currently extend to `now`. This PR adds support for `Now`, `NOW`, etc.