### PR TITLE
Add compatibility with core-js

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -16,7 +16,7 @@
   var internalToString = object.prototype.toString;
 
   // Are regexes type function?
-  var regexIsFunction = typeof regexp() === 'function';
+  var regexIsFunction = typeof regexp(/x/) === 'function';
 
   // Do strings have no keys?
   var noKeysInStringObjects = !('0' in new string('a'));


### PR DESCRIPTION
According to [RegExp documentation in ECMAScript 6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp), the `pattern` argument is mandatory.

How to reproduce:
```js
$ npm install core-js sugar
$ node
> require('core-js');
> require('sugar');

TypeError: Cannot read property 'flags' of undefined
    at RegExp
(/private/tmp/node_modules/core-js/modules/es6.regexp.js:21:38)
    at Object.<anonymous>
(/private/tmp/node_modules/sugar/release/sugar-full.development.js:35:32)
    at Object.<anonymous>
(/private/tmp/node_modules/sugar/release/sugar-full.development.js:9245:4)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at repl:1:1
```

After the change of this commit, it works.