### PR TITLE
Added option for non-strict parsing of date strings in Date.create()

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -429,6 +429,7 @@
       variant: !!variant,
       locale: locale,
       reg: regexp('^' + format + '$', 'i'),
+      pattern: regexp(format, 'i'),
       to: match
     });
   }
@@ -635,7 +636,7 @@
     });
   }
 
-  function getExtendedDate(contextDate, f, localeCode, prefer, forceUTC) {
+  function getExtendedDate(contextDate, f, localeCode, prefer, forceUTC, loose) {
     // TODO can we split this up into smaller methods?
     var d, relative, baseLocalization, afterCallbacks, loc, set, unit, unitIndex, weekday, num, tmp, weekdayForward;
 
@@ -709,7 +710,40 @@
       }
     }
 
+    function getDateString(string) {
+      var match, dateString = [];
+      // Match browser-recognized date formats.
+      match = string.match(/\d+(\/|-)+\d*(\/|-)*\d*([^\S\n]|T)?\d*:*\d*:*\d*/);
+      if (match) {
+        return match[0];
+      } else if (baseLocalization) {
+        iterateOverObject(baseLocalization.getFormats(), function(i, dif) {
+          match = string.match(dif.pattern);
+          if(match) {
+            // Take the longest matching date string.
+            dateString = (dateString.length < match.length) ? match : dateString;
+          }
+        });
+        if (dateString.length > 0) { 
+          return dateString[0];
+        } else {
+          if (/now/.test(string)) {
+            return "now"
+          }
+        }
+      }
+      return "";
+    }
+
     setUTC(d, forceUTC);
+
+    // The act of getting the localization will pre-initialize
+    // if it is missing and add the required formats.
+    baseLocalization = getLocalization(localeCode);
+
+    if (loose) {
+      f = getDateString(f);
+    }
 
     if(isDate(f)) {
       // If the source here is already a date object, then the operation
@@ -721,10 +755,6 @@
       setDate(d, [f, true]);
       set = f;
     } else if(isString(f)) {
-
-      // The act of getting the localization will pre-initialize
-      // if it is missing and add the required formats.
-      baseLocalization = getLocalization(localeCode);
 
       // Clean the input and convert Kanji based numerals if they exist.
       f = cleanDateInput(f);
@@ -1336,20 +1366,25 @@
   }
 
   function createDateFromArgs(contextDate, args, prefer, forceUTC) {
-    var f, localeCode;
+    var f, localeCode, loose;
     if(isNumber(args[1])) {
       // If the second argument is a number, then we have an
       // enumerated constructor type as in "new Date(2003, 2, 12);"
       f = collectDateArguments(args)[0];
     } else {
       f = args[0];
-      localeCode = args[1];
+      if (isBoolean(args[1])) {
+        loose = args[1];
+      } else {
+        localeCode = args[1];
+        loose = args[2];
+      }
     }
-    return createDate(contextDate, f, localeCode, prefer, forceUTC);
+    return createDate(contextDate, f, localeCode, prefer, forceUTC, loose);
   }
 
-  function createDate(contextDate, f, localeCode, prefer, forceUTC) {
-    return getExtendedDate(contextDate, f, localeCode, prefer, forceUTC).date;
+  function createDate(contextDate, f, localeCode, prefer, forceUTC, loose) {
+    return getExtendedDate(contextDate, f, localeCode, prefer, forceUTC, loose).date;
   }
 
   function invalidateDate(d) {
@@ -1835,10 +1870,10 @@
   extend(date, {
 
      /***
-     * @method Date.create(<d>, [locale] = currentLocale)
+     * @method Date.create(<d>, [locale] = currentLocale, [loose] = false)
      * @returns Date
      * @short Alternate Date constructor which understands many different text formats, a timestamp, or another date.
-     * @extra If no argument is given, date is assumed to be now. %Date.create% additionally can accept enumerated parameters as with the standard date constructor. [locale] can be passed to specify the locale that the date is in. When unspecified, the current locale (default is English) is assumed. UTC-based dates can be created through the %utc% object. For more see @date_format.
+     * @extra If no argument is given, date is assumed to be now. %Date.create% additionally can accept enumerated parameters as with the standard date constructor. [locale] can be passed to specify the locale that the date is in. When unspecified, the current locale (default is English) is assumed. If [loose] is %true%, ambiguous input will be parsed to find a date string. UTC-based dates can be created through the %utc% object. For more see @date_format.
      * @set
      *   Date.utc.create
      *
@@ -1853,6 +1888,7 @@
      *   Date.create(-446806800000)   -> November 5, 1955
      *   Date.create(1776, 6, 4)      -> July 4, 1776
      *   Date.create('1776年07月04日', 'ja') -> July 4, 1776
+     *   Date.create('The meeting is tomorrow', true) -> tomorrow
      *   Date.utc.create('July 4, 1776', 'en')  -> July 4, 1776
      *
      ***/
@@ -1861,7 +1897,7 @@
     },
 
      /***
-     * @method Date.past(<d>, [locale] = currentLocale)
+     * @method Date.past(<d>, [locale] = currentLocale, [loose] = false)
      * @returns Date
      * @short Alternate form of %Date.create% with any ambiguity assumed to be the past.
      * @extra For example %"Sunday"% can be either "the Sunday coming up" or "the Sunday last" depending on context. Note that dates explicitly in the future ("next Sunday") will remain in the future. This method simply provides a hint when ambiguity exists. UTC-based dates can be created through the %utc% object. For more, see @date_format.
@@ -1879,7 +1915,7 @@
     },
 
      /***
-     * @method Date.future(<d>, [locale] = currentLocale)
+     * @method Date.future(<d>, [locale] = currentLocale, [loose] = false)
      * @returns Date
      * @short Alternate form of %Date.create% with any ambiguity assumed to be the future.
      * @extra For example %"Sunday"% can be either "the Sunday coming up" or "the Sunday last" depending on context. Note that dates explicitly in the past ("last Sunday") will remain in the past. This method simply provides a hint when ambiguity exists. UTC-based dates can be created through the %utc% object. For more, see @date_format.

--- a/lib/date.js
+++ b/lib/date.js
@@ -727,7 +727,7 @@
         if (dateString.length > 0) { 
           return dateString[0];
         } else {
-          if (/now/.test(string)) {
+          if (/now/i.test(string)) {
             return "now"
           }
         }


### PR DESCRIPTION
This resolves #297 by creating an option for non-strict parsing when creating a new date. I added a boolean argument 'loose' to Date.create(), Date.past() and Date.future. When it's passed as true, a date string will be extracted from the input by comparing it to non-strict Date Input Format regexs from the appropriate locale.