### PR TITLE
check second argument type in Object.keys()

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -295,7 +295,7 @@
       return keys;
     }
 
-  }, false, function() { return arguments.length > 1; });
+  }, false, function() { return arguments.length > 1 && typeof arguments[1] === 'function'; });
 
   extend(object, {
 

--- a/test/environments/sugar/object.js
+++ b/test/environments/sugar/object.js
@@ -223,6 +223,7 @@ package('Object', function () {
       count++;
     }]);
     equal(count, 3, 'Object.keys | accepts a block | iterated properly');
+    equal(run(Object, 'keys', [obj, "Not a function"]), keys, "Object,keys | ignores second argument if not a function");
 
     strippedValues = obj.values().filter(function(m) { return typeof m != 'function'; });
     equal(strippedValues, values, "returns object's values");

--- a/test/object.html
+++ b/test/object.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Sugar and Dates (Array Package)</title>
+    <title>Sugar (Object Package)</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <link rel="stylesheet" href="stylesheets/custom.css" type="text/css" />
     <link rel="stylesheet" href="stylesheets/tooltip.css" type="text/css" />


### PR DESCRIPTION
Hi,

Here's a fix proposal for #525, checking for the type of the second argument in Object.keys.

The goal is to avoid clashes with code such as ```[obj1, obj2].map(Object.keys);```

As specified in the documentation, I didn't regenerate the /release artifacts.
However "npm test" is relying on sugar-full.dev.js to run so it fails for now.
-> Should I rebuild the release files here ?

