### PR TITLE
bower.json main script path update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "date",
     "time"
   ],
-  "main": "sugar.js",
+  "main": "release/sugar.js",
   "ignore": [
     "lib",
     "test",


### PR DESCRIPTION
Hi There,
I'm sorry for unsolicited pull request. There is super minor thing that was messing up our project. As Sugar is being build into the "release" folder the "bower.json – main" entry-point does not reflect this and thus automated services (in our case grunt wiredep) that depend on this data can't see sugar lib.

Thank you,
Tomas