### PR TITLE
docs(README.md) fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,28 +156,28 @@ Other non-default modules can be found individually (i.e. `sugar-language`, etc)
 
 ## Date Locales
 
-Locale definition files are in the [locales](locales/) directory. They can be
+Locale definition files are in the [locales](lib/locales/) directory. They can be
 simply included as-is after Sugar is loaded, or built together using
 [custom builds](#custom-builds). English is included by default and required by
 the Date module. Currently available locales are:
 
-- [Catalan (ca)](locales/ca.js)
-- [Danish (da)](locales/da.js)
-- [Dutch (nl)](locales/nl.js)
-- [Finnish (fi)](locales/fi.js)
-- [French (fr)](locales/fr.js)
-- [German (de)](locales/de.js)
-- [Italian (it)](locales/it.js)
-- [Japanese (ja)](locales/ja.js)
-- [Korean (ko)](locales/ko.js)
-- [Norwegian (no)](locales/no.js)
-- [Polish (pl)](locales/pl.js)
-- [Portuguese (pt)](locales/pt.js)
-- [Russian (ru)](locales/ru.js)
-- [Spanish (es)](locales/es.js)
-- [Swedish (sv)](locales/sv.js)
-- [Simplified Chinese (zh-CN)](locales/zh-CN.js)
-- [Traditional Chinese (zh-TW)](locales/zh-TW.js)
+- [Catalan (ca)](lib/locales/ca.js)
+- [Danish (da)](lib/locales/da.js)
+- [Dutch (nl)](lib/locales/nl.js)
+- [Finnish (fi)](lib/locales/fi.js)
+- [French (fr)](lib/locales/fr.js)
+- [German (de)](lib/locales/de.js)
+- [Italian (it)](lib/locales/it.js)
+- [Japanese (ja)](lib/locales/ja.js)
+- [Korean (ko)](lib/locales/ko.js)
+- [Norwegian (no)](lib/locales/no.js)
+- [Polish (pl)](lib/locales/pl.js)
+- [Portuguese (pt)](lib/locales/pt.js)
+- [Russian (ru)](lib/locales/ru.js)
+- [Spanish (es)](lib/locales/es.js)
+- [Swedish (sv)](lib/locales/sv.js)
+- [Simplified Chinese (zh-CN)](lib/locales/zh-CN.js)
+- [Traditional Chinese (zh-TW)](lib/locales/zh-TW.js)
 
 #### Adding/Customizing Locales
 


### PR DESCRIPTION
- Fix broken links to the `locales` directory