### PR TITLE
Fix for getting global context in recent Firefox and Thunderbird

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -50,8 +50,13 @@ var DefaultChainable = getNewChainableClass('Chainable');
 function getGlobal() {
   // Get global context by keyword here to avoid issues with libraries
   // that can potentially alter this script's context object.
-  return testGlobal(typeof global !== 'undefined' && global) ||
-         testGlobal(typeof window !== 'undefined' && window);
+  var ret = testGlobal(typeof global !== 'undefined' && global) ||
+            testGlobal(typeof window !== 'undefined' && window);
+  if (ret) return ret;
+  // Firefox / Thunderbird specific
+  if (typeof Cu != 'undefined' && typeof Cu.getGlobalForObject != 'undefined')
+    ret = testGlobal(Cu.getGlobalForObject(getGlobal));
+  return ret;
 }
 
 function testGlobal(obj) {


### PR DESCRIPTION
If we can't get the global contest from either `global` or `window`
and `Cu.getGlobalForObject` exists, then use that.

See https://developer.mozilla.org/docs/Mozilla/Tech/XPCOM/Language_Bindings/Components.utils.getGlobalForObject.

Fixes andrewplummer/Sugar#627.