### PR TITLE
Parse dd mmm yyyy hh:mm and weekday, dd mm yyyy hh:mm in Polish

### DIFF
--- a/lib/locales/pl.js
+++ b/lib/locales/pl.js
@@ -74,6 +74,10 @@ Sugar.Date.addLocale('pl', {
     '{shift} {unit:5-7}',
     '{0} {shift?} {weekday}'
   ],
+  'timeParse': [
+    '{date} {months} {year?}',
+    '{weekday?}\\.?,? {date} {months} {year?}'
+  ],
   'timeFrontParse': [
     '{day|weekday}',
     '{date} {months} {year?} {1?}',


### PR DESCRIPTION
Fixes andrewplummer/Sugar#662

I don't know if this is a complete fix because the date-parsing stuff
is quite arcane and I don't fully understand it, but this at least
seems to solve the problem of Sugar being unable to parse Polish dates
that it has itself formatted.