### PR TITLE
Only call localCheck when time is involved

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -2477,15 +2477,12 @@ function getNewLocale(def) {
       function addCoreFormats() {
         forEach(CoreParsingFormats, function(df) {
           var src = df.src;
-          if (df.localeCheck && !df.localeCheck(loc)) {
-            return;
-          }
           if (df.mdy && loc.mdy) {
             // Use the mm/dd/yyyy variant if it
             // exists and the locale requires it
             src = df.mdy;
           }
-          if (df.time) {
+          if (df.time && !df.localeCheck || (df.localeCheck && !df.localeCheck(loc))) {
             // Core formats that allow time require the time
             // reg on both sides, so add both versions here.
             loc.addFormat(getFormatWithTime(src, true));

--- a/test/tests/locales/fi.js
+++ b/test/tests/locales/fi.js
@@ -11,6 +11,7 @@ namespace('Date | Finnish', function () {
 
   method('create', function() {
 
+    assertDateParsed('1.12.2019', new Date(2019, 11, 1));
     assertDateParsed('15. toukokuuta 2011', new Date(2011, 4, 15));
     assertDateParsed('torstai 5. tammikuuta 2012', new Date(2012, 0, 5));
     assertDateParsed('torstaina 5. tammikuuta 2012', new Date(2012, 0, 5));


### PR DESCRIPTION
This is an attempt to fix this issue:
https://github.com/andrewplummer/Sugar/issues/648

After looking into the issue, it appears as though the `localeCheck` function is causing the issue.  From what I can tell, it should only apply when there is a time to consider.  I've moved the `localCheck` into the branching logic for `addCoreFormats` where it is also checking for time.

I wrote a test that takes both issues mentioned into account, where a date of December 1 is showing up as January 12th, as well as the original issue where "Invalid Date" was being returned when creating a date without time using dot notation.