### PR TITLE
still setting module.exports when reusing already defined global object

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -64,6 +64,11 @@ function setupGlobal() {
   Sugar = globalContext[SUGAR_GLOBAL];
   // istanbul ignore if
   if (Sugar) {
+    if (typeof module !== 'undefined' && module.exports) {
+      // Node or webpack environment
+      module.exports = Sugar;
+    }
+    
     // Reuse already defined Sugar global object.
     return;
   }


### PR DESCRIPTION
this resolves issues when using the npm module after having Sugar already loaded globally

resolves #690 